### PR TITLE
Custom map wrapper

### DIFF
--- a/src/main/java/test/MyMapWrapper.java
+++ b/src/main/java/test/MyMapWrapper.java
@@ -1,0 +1,129 @@
+package test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.reflection.SystemMetaObject;
+import org.apache.ibatis.reflection.factory.ObjectFactory;
+import org.apache.ibatis.reflection.property.PropertyTokenizer;
+import org.apache.ibatis.reflection.wrapper.BaseWrapper;
+
+public class MyMapWrapper extends BaseWrapper {
+
+  private final Map<String, Object> map;
+
+  public MyMapWrapper(MetaObject metaObject, Map<String, Object> map) {
+    super(metaObject);
+    this.map = map;
+  }
+
+  @Override
+  public Object get(PropertyTokenizer prop) {
+    return map.get(prop.getIndexedName());
+  }
+
+  @Override
+  public void set(PropertyTokenizer prop, Object value) {
+    map.put(prop.getIndexedName(), value);
+  }
+
+  @Override
+  public String findProperty(String name, boolean useCamelCaseMapping) {
+    return name;
+  }
+
+  @Override
+  public String[] getGetterNames() {
+    return map.keySet().toArray(new String[0]);
+  }
+
+  @Override
+  public String[] getSetterNames() {
+    return map.keySet().toArray(new String[0]);
+  }
+
+  @Override
+  public Class<?> getSetterType(String name) {
+    PropertyTokenizer prop = new PropertyTokenizer(name);
+    if (prop.hasNext()) {
+      MetaObject metaValue = metaObject.metaObjectForProperty(prop.getIndexedName());
+      if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
+        return Object.class;
+      } else {
+        return metaValue.getSetterType(prop.getChildren());
+      }
+    }
+    if (map.get(name) != null) {
+      return map.get(name).getClass();
+    } else {
+      return Object.class;
+    }
+  }
+
+  @Override
+  public Class<?> getGetterType(String name) {
+    PropertyTokenizer prop = new PropertyTokenizer(name);
+    if (prop.hasNext()) {
+      MetaObject metaValue = metaObject.metaObjectForProperty(prop.getIndexedName());
+      if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
+        return Object.class;
+      } else {
+        return metaValue.getGetterType(prop.getChildren());
+      }
+    }
+    if (map.get(name) != null) {
+      return map.get(name).getClass();
+    } else {
+      return Object.class;
+    }
+  }
+
+  @Override
+  public boolean hasSetter(String name) {
+    return true;
+  }
+
+  @Override
+  public boolean hasGetter(String name) {
+    PropertyTokenizer prop = new PropertyTokenizer(name);
+    if (!prop.hasNext()) {
+      return map.containsKey(prop.getName());
+    }
+    if (map.containsKey(prop.getIndexedName())) {
+      MetaObject metaValue = metaObject.metaObjectForProperty(prop.getIndexedName());
+      if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
+        return true;
+      } else {
+        return metaValue.hasGetter(prop.getChildren());
+      }
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public MetaObject instantiatePropertyValue(String name, PropertyTokenizer prop, ObjectFactory objectFactory) {
+    HashMap<String, Object> map = new HashMap<>();
+    set(prop, map);
+    return MetaObject.forObject(map, metaObject.getObjectFactory(), metaObject.getObjectWrapperFactory(),
+        metaObject.getReflectorFactory());
+  }
+
+  @Override
+  public boolean isCollection() {
+    return false;
+  }
+
+  @Override
+  public void add(Object element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <E> void addAll(List<E> element) {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/src/main/java/test/MyObjectWrapperFactory.java
+++ b/src/main/java/test/MyObjectWrapperFactory.java
@@ -1,0 +1,23 @@
+package test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.reflection.wrapper.ObjectWrapper;
+import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
+
+public class MyObjectWrapperFactory implements ObjectWrapperFactory {
+
+  @Override
+  public boolean hasWrapperFor(Object object) {
+    return object instanceof LinkedHashMap;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public ObjectWrapper getWrapperFor(MetaObject metaObject, Object object) {
+    return new MyMapWrapper(metaObject, (Map<String, Object>) object);
+  }
+
+}

--- a/src/main/resources/test/mybatis-config.xml
+++ b/src/main/resources/test/mybatis-config.xml
@@ -5,6 +5,8 @@
 
 <configuration>
 
+  <objectWrapperFactory type="test.MyObjectWrapperFactory" />
+
   <environments default="development">
     <environment id="development">
       <transactionManager type="JDBC">

--- a/src/test/java/test/MyMapWrapperTest.java
+++ b/src/test/java/test/MyMapWrapperTest.java
@@ -1,0 +1,38 @@
+package test;
+
+import static org.junit.Assert.*;
+
+import java.util.LinkedHashMap;
+
+import org.apache.ibatis.reflection.DefaultReflectorFactory;
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
+import org.apache.ibatis.reflection.wrapper.DefaultObjectWrapperFactory;
+import org.junit.Test;
+
+public class MyMapWrapperTest {
+
+  @Test
+  public void demoCustomMapWrapper() {
+    LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+    MetaObject metaObj = MetaObject.forObject(map,
+        new DefaultObjectFactory(),
+        new MyObjectWrapperFactory(),
+        new DefaultReflectorFactory());
+    metaObj.setValue("100[a]", "x");
+
+    assertEquals("x", map.get("100[a]"));
+  }
+
+  @Test
+  public void demoDefaultMapWrapper() {
+    LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+    MetaObject metaObj = MetaObject.forObject(map,
+        new DefaultObjectFactory(),
+        new DefaultObjectWrapperFactory(),
+        new DefaultReflectorFactory());
+    // The following line throws the NumberFormatException
+    metaObj.setValue("100[a]", "x");
+  }
+
+}

--- a/src/test/java/test/SimpleTest.java
+++ b/src/test/java/test/SimpleTest.java
@@ -75,7 +75,7 @@ public class SimpleTest {
     }
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
-      String sql="select case when name='aaa[张三]' then 1 else 0 end as 'aaa[张三]' from users limit 1" ;
+      String sql="select case when name='aaa[张三]' then 1 else 0 end as \"aaa[张三]\" from users limit 1" ;
       JSONObject jsonObject=new JSONObject();
       jsonObject.putIfAbsent("__sql__",sql);
       List<LinkedHashMap<String, ?>> linkedHashMaps = mapper.queryListByDynamicSql(jsonObject);


### PR DESCRIPTION
The first commit fixes an SQL error.

The second commit adds a custom `ObjectWrapper` and `ObjectWrapperFactory`.
It's only applied to `LinkedHashMap`, but it can be applied to `Map` in general if that's what you want (just replace `LinkedHashMap` with `Map` in these classes).

You should test it thoroughly before using it in production.